### PR TITLE
fix/utf8-for-geobasis-nrw

### DIFF
--- a/er/participanting-organizations/CologneGovernmentRegionalOffice.adoc
+++ b/er/participanting-organizations/CologneGovernmentRegionalOffice.adoc
@@ -1,7 +1,7 @@
 [[CologneGovernmentRegionalOffice]]
 === Cologne Government Regional Office - Geobasis NRW
 
-Division 7 of the Cologne Government Regional Office is North Rhine-Westphalia‘s central service for geographic reference data and top-quality geo-products and services. Division 7 has statewide responsibility for collecting, storing, handling and making available basic topographic geodata. The basic geodata provided by Division 7 (coordinates, elevations, property boundaries, size and use of real estate, topographic information etc.) are needed for a wide range of purposes including planning, construction projects, transport and the supply of basic community services, nature conservation and environmental protection, valuation of real property, real estate transactions and mortgage borrowing. Against a background of rapid technological progress and changing environmental awareness, the division‘s services are now in demand from new sections of the community. Rather than chiefly asking for analogue data such as maps, plans and lists, users increasingly prefer digital information which they can integrate into existing databases.
+Division 7 of the Cologne Government Regional Office is North Rhine-Westphaliaâ€™s central service for geographic reference data and top-quality geo-products and services. Division 7 has statewide responsibility for collecting, storing, handling and making available basic topographic geodata. The basic geodata provided by Division 7 (coordinates, elevations, property boundaries, size and use of real estate, topographic information etc.) are needed for a wide range of purposes including planning, construction projects, transport and the supply of basic community services, nature conservation and environmental protection, valuation of real property, real estate transactions and mortgage borrowing. Against a background of rapid technological progress and changing environmental awareness, the divisionâ€™s services are now in demand from new sections of the community. Rather than chiefly asking for analogue data such as maps, plans and lists, users increasingly prefer digital information which they can integrate into existing databases.
 
 ==== Motivation to Participate
 
@@ -14,8 +14,8 @@ During the OGC API Hackathon event in London, Geobasis NRW implemented the OGC A
 Before the OGC API Hackathon, Geobasis NRW implemented the OGC API for Features by using ldproxy (https://www.ldproxy.nrw.de/). Have a look on the functionality:
 
 * Extras / Verwaltungseinheit
-* Extras / Flurstück
-* Extras / Gebäude
+* Extras / FlurstÃ¼ck
+* Extras / GebÃ¤ude
 
 Implementation available: https://www.tim-online.nrw.de/ogc-hackathon/
 


### PR DESCRIPTION
The text encoding in the file CologneGovernmentRegionalOffice.adoc was not UTF-8 and fails the asciidoctor build for me.

This merge request corrects the encoding.